### PR TITLE
FIX: Importing for __version__ broke install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8 'setuptools<20.5.0' jinja2
+  - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8 'setuptools<20.5.0'
   - source activate test-env
   - pip install .
 script:

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,22 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import re
+import ast
+
 from setuptools import setup, find_packages
 
-import q2templates
+# version parsing from __init__ pulled from Flask's setup.py
+# https://github.com/mitsuhiko/flask/blob/master/setup.py
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+
+with open('q2templates/__init__.py', 'rb') as f:
+    hit = _version_re.search(f.read().decode('utf-8')).group(1)
+    version = str(ast.literal_eval(hit))
 
 setup(
     name="q2templates",
-    version=q2templates.__version__,
+    version=version,
     license='BSD-3-Clause',
     packages=find_packages(exclude=['tests']),
     package_data={


### PR DESCRIPTION
Fixes install issue with `jinja2`. Importing `q2templates` for the `__version__` in `setup.py` was trying to "load" Jinja before it was even installed.