### PR TITLE
ENH: Remove header when in a nested view.

### DIFF
--- a/q2templates/templates/base.html
+++ b/q2templates/templates/base.html
@@ -12,10 +12,10 @@
   </head>
   <body>
     <div class="container-fluid">
-      <div class="row">
+      <div id="q2templatesheader" class="row">
         <div class="col-lg-12">
           <a href="http://qiime2.org/">
-            <img class="header" src="./q2templateassets/img/qiime2-rect-200.png"
+            <img src="./q2templateassets/img/qiime2-rect-200.png"
             alt="QIIME 2">
           </a>
         </div>
@@ -23,5 +23,10 @@
         {% block content %}
         {% endblock %}
     </div>
+    <script type="text/javascript">
+      if (window.frameElement) {
+          document.getElementById('q2templatesheader').remove();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Removes header image when inside of a site like view.qiime2.org, this does not work in `q2studio`, as a `webview`, that is used to display visualizations, is basically undetectable from within (that's why sites like Facebook that don't work in iframes, work in webviews).