### PR TITLE
ENH: Add child.html style for no header image iframes.

### DIFF
--- a/q2templates/templates/child.html
+++ b/q2templates/templates/child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% block title %}{{ q2templates_default_page_title }}{% endblock %}</title>
+    <link rel="stylesheet" href="./q2templateassets/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="./q2templateassets/css/normalize.css"/>
+    {% block head %}
+    {% endblock %}
+  </head>
+  <body>
+    <div class="container-fluid">
+        {% block content %}
+        {% endblock %}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Discovered an issue where you might need a logo-less child page for iframes.

Related to qiime2/q2-feature-table/pull/66