### PR TITLE
ENH: Create tab handling template

### DIFF
--- a/q2templates/templates/assets/css/tab-parent.css
+++ b/q2templates/templates/assets/css/tab-parent.css
@@ -1,0 +1,15 @@
+/*
+----------------------------------------------------------------------------
+Copyright (c) 2016-2017, QIIME 2 development team.
+
+Distributed under the terms of the Modified BSD License.
+
+The full license is in the file LICENSE, distributed with this software.
+----------------------------------------------------------------------------
+*/
+
+#tab-frame {
+  margin-top: 15px;
+  border: none;
+  width: 100%;
+}

--- a/q2templates/templates/assets/js/child.js
+++ b/q2templates/templates/assets/js/child.js
@@ -1,0 +1,17 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016-2017, QIIME 2 development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
+
+document.addEventListener('DOMContentLoaded', function() {
+  var height = Math.max(
+    Math.max(document.body.scrollHeight, document.documentElement.scrollHeight),
+    Math.max(document.body.offsetHeight, document.documentElement.offsetHeight),
+    Math.max(document.body.clientHeight, document.documentElement.clientHeight)
+  );
+  parent.postMessage(height, '*');
+});

--- a/q2templates/templates/assets/js/parent.js
+++ b/q2templates/templates/assets/js/parent.js
@@ -1,0 +1,32 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016-2017, QIIME 2 development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
+var frame;
+
+function frameLoad(event) {
+  frame.height = `${event.data + 50}px`;
+}
+
+function toggleClass() {
+  if (document.querySelector('.active').id != this.id) {
+    document.querySelector('.active').className = '';
+    this.className = 'active';
+    frame.height = '0px';
+    frame.src = frameSrc[this.id];
+  }
+}
+
+function init() {
+  for (const frame of Object.keys(frameSrc)) {
+    document.getElementById(frame).addEventListener('click', toggleClass);
+  }
+  frame = document.getElementById('tab-frame');
+}
+
+document.addEventListener('DOMContentLoaded', init);
+window.addEventListener('message', frameLoad);

--- a/q2templates/templates/tab-child.html
+++ b/q2templates/templates/tab-child.html
@@ -7,6 +7,7 @@
     <title>{% block title %}{{ q2templates_default_page_title }}{% endblock %}</title>
     <link rel="stylesheet" href="./q2templateassets/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="./q2templateassets/css/normalize.css"/>
+    <script src="./q2templateassets/js/child.js"></script>
     {% block head %}
     {% endblock %}
   </head>

--- a/q2templates/templates/tab-parent.html
+++ b/q2templates/templates/tab-parent.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% block title %}{{ q2templates_default_page_title }}{% endblock %}</title>
+    <link rel="stylesheet" href="./q2templateassets/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="./q2templateassets/css/normalize.css"/>
+    <link rel="stylesheet" href="./q2templateassets/css/tab-parent.css">
+    <script src="./q2templateassets/js/parent.js"></script>
+  </head>
+  <body>
+    <div class="container-fluid">
+      <div id="q2templatesheader" class="row">
+        <div class="col-lg-12">
+          <a href="http://qiime2.org/">
+            <img src="./q2templateassets/img/qiime2-rect-200.png"
+            alt="QIIME 2">
+          </a>
+        </div>
+      </div>
+      <div class="row">
+        <ul class="nav nav-tabs">
+          <li id="{{ tabs[0].url.split('.')[0] }}" class="active"><a href="#">{{ tabs[0].title }}</a></li>
+          {% for tab in tabs[1:] %}
+          <li id="{{ tab.url.split('.')[0] }}"><a href="#">{{ tab.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      <iframe id="tab-frame" src="./{{ tabs[0].url }}"></iframe>
+    </div>
+    <script type="text/javascript">
+      if (window.frameElement) {
+          document.getElementById('q2templatesheader').remove();
+      }
+      var frameSrc = {
+        {% for tab in tabs %}
+        '{{ tab.url.split('.')[0] }}': './{{ tab.url }}',
+        {% endfor %}
+      };
+    </script>
+  </body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,12 @@ setup(
     version='2017.2.0.dev0',
     license='BSD-3-Clause',
     url='https://qiime2.org',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(),
     package_data={
         'q2templates': [
             'templates/*.html',
             'templates/assets/css/*.css',
+            'templates/assets/js/*.js',
             'templates/assets/img/*.png',
             'templates/assets/fonts/glyphicons-*'
         ]


### PR DESCRIPTION
q2-feature-table and now a q2-demux viz will require using tabbed views. Instead of duplicating logic, as they both use q2templates, it makes sense to move the functionality to this package.

This also removes the need to specify templates through `styles=...` as they are now parsed from the source files. Will open `q2-feature-table` PR to test against.