### PR TITLE
Fixes extended scroll bug

### DIFF
--- a/q2templates/templates/assets/js/child.js
+++ b/q2templates/templates/assets/js/child.js
@@ -8,10 +8,16 @@
 
 
 document.addEventListener('DOMContentLoaded', function() {
+  if (document.body.scrollHeight !== document.documentElement.scrollHeight) {
+    scrollHeight = document.documentElement.scrollHeight
+  } else {
+    scrollHeight = document.body.scrollHeight
+  }
   var height = Math.max(
-    Math.max(document.body.scrollHeight, document.documentElement.scrollHeight),
+    scrollHeight,
     Math.max(document.body.offsetHeight, document.documentElement.offsetHeight),
     Math.max(document.body.clientHeight, document.documentElement.clientHeight)
   );
+  var height = document.documentElement.scrollHeight
   parent.postMessage(height, '*');
 });


### PR DESCRIPTION
Fixes https://github.com/qiime2/q2-feature-table/issues/115

Page no longer has trailing whitespace carried over from previous page when pressing the back button after clicking HTML link. 

There are no tests for this plugin, but I ran over the entire [moving pictures tutorial](https://docs.qiime2.org/2017.6/tutorials/moving-pictures/), and the fix does not appear to break any other visualizers.