### PR TITLE
ENH: add `q2templates.df_to_html` function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ before_install:
 install:
   - conda create -q -n test-env --file https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-conda-linux-64.txt
   - source activate test-env
+  - conda install -q pytest
   - pip install -q flake8
   - pip install -q https://github.com/qiime2/q2lint/archive/master.zip
   - make install
 script:
   - make lint
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint test test-cov install dev clean distclean
+.PHONY: all lint test install dev clean distclean
 
 all: ;
 
@@ -7,8 +7,7 @@ lint:
 	flake8
 
 test: all
-
-test-cov: all
+	py.test
 
 install: all
 	python setup.py install

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python 3.5*
     - setuptools
     - jinja2
+    - pandas
 
 test:
   imports:

--- a/q2templates/__init__.py
+++ b/q2templates/__init__.py
@@ -7,10 +7,11 @@
 # ----------------------------------------------------------------------------
 
 from ._templates import render
+from .util import df_to_html
 from ._version import get_versions
 
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['render']
+__all__ = ['render', 'df_to_html']

--- a/q2templates/tests/test_util.py
+++ b/q2templates/tests/test_util.py
@@ -1,0 +1,51 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import pandas as pd
+
+from q2templates import df_to_html
+
+
+class TestDataFrameToHTML(unittest.TestCase):
+    def test_no_truncation(self):
+        long_cell = 'baz' * 100
+        df = pd.DataFrame({'col': ['foo', 'bar', long_cell]})
+
+        obs = df_to_html(df)
+
+        self.assertIn('col', obs)
+        self.assertIn('foo', obs)
+        self.assertIn('bar', obs)
+        self.assertIn(long_cell, obs)
+
+    def test_defaults(self):
+        df = pd.DataFrame({'col1': ['foo', 'bar', 'baz'], 'col2': [1, 2, 4.2]})
+
+        obs = df_to_html(df)
+
+        self.assertIn('border="0"', obs)
+        self.assertIn('table table-striped table-hover', obs)
+
+    def test_defaults_override(self):
+        df = pd.DataFrame({'col1': ['foo', 'bar', 'baz'], 'col2': [1, 2, 4.2]},
+                          index=['id1', 'id2', 'id3'])
+
+        obs = df_to_html(df, border=1, classes=('class1', 'class2'),
+                         index=False)
+
+        self.assertIn('border="1"', obs)
+        self.assertIn('class1 class2', obs)
+        self.assertNotIn('id1', obs)
+        self.assertNotIn('id2', obs)
+        self.assertNotIn('id3', obs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2templates/util.py
+++ b/q2templates/util.py
@@ -9,6 +9,42 @@
 import os
 import shutil
 
+import pandas as pd
+
+
+def df_to_html(df, border=0, classes=('table', 'table-striped', 'table-hover'),
+               **kwargs):
+    """Convert a dataframe to HTML without truncating contents.
+
+    pandas will truncate cell contents that exceed 50 characters by default.
+    Use this function to avoid this truncation behavior.
+
+    This function uses different default parameters than `DataFrame.to_html` to
+    give uniform styling to HTML tables that are compatible with q2template
+    themes. These parameters can be overridden, and they (along with any other
+    parameters) will be passed through to `DataFrame.to_html`.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to convert to HTML.
+    kwargs : dict
+        Parameters passed through to `pd.DataFrame.to_html`.
+
+    Returns
+    -------
+    str
+        DataFrame converted to HTML.
+
+    References
+    ----------
+    .. [1] https://stackoverflow.com/q/26277757/3776794
+    .. [2] https://github.com/pandas-dev/pandas/issues/1852
+
+    """
+    with pd.option_context('display.max_colwidth', -1):
+        return df.to_html(border=border, classes=classes, **kwargs)
+
 
 def copy_assets(source_dir, output_dir):
     # Copy into existing dir: http://stackoverflow.com/a/12514470/4760331


### PR DESCRIPTION
This utility function wraps `DataFrame.to_html` to avoid truncation of cell contents in the output HTML. Default pandas behavior is to truncate cell contents that exceed 50 characters.

The function also uses different default parameters than `DataFrame.to_html` to give uniform styling to HTML tables that are compatible with q2template themes. These defaults can be overridden.