### PR TITLE
Allow for compatibility for pandas>=0.25.3

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python {{ python }}
     - setuptools
     - jinja2
-    - pandas
+    - pandas >=1
 
 test:
   imports:

--- a/q2templates/util.py
+++ b/q2templates/util.py
@@ -42,8 +42,13 @@ def df_to_html(df, border=0, classes=('table', 'table-striped', 'table-hover'),
     .. [2] https://github.com/pandas-dev/pandas/issues/1852
 
     """
-    with pd.option_context('display.max_colwidth', -1):
-        return df.to_html(border=border, classes=classes, **kwargs)
+    try:
+        with pd.option_context('display.max_colwidth', -1):
+            return df.to_html(border=border, classes=classes, **kwargs)
+    except ValueError:
+        # Supports pandas API changes starting in 1.0
+        with pd.option_context('display.max_colwidth', None):
+            return df.to_html(border=border, classes=classes, **kwargs)
 
 
 def copy_assets(source_dir, output_dir):

--- a/q2templates/util.py
+++ b/q2templates/util.py
@@ -42,13 +42,8 @@ def df_to_html(df, border=0, classes=('table', 'table-striped', 'table-hover'),
     .. [2] https://github.com/pandas-dev/pandas/issues/1852
 
     """
-    try:
-        with pd.option_context('display.max_colwidth', -1):
-            return df.to_html(border=border, classes=classes, **kwargs)
-    except ValueError:
-        # Supports pandas API changes starting in 1.0
-        with pd.option_context('display.max_colwidth', None):
-            return df.to_html(border=border, classes=classes, **kwargs)
+    with pd.option_context('display.max_colwidth', None):
+        return df.to_html(border=border, classes=classes, **kwargs)
 
 
 def copy_assets(source_dir, output_dir):


### PR DESCRIPTION
closes #41 

I tried to be cute with `max_colwidth = None if float(pd.__version__) >= 1.0 else -1` but...
```python
>>> float("0.25.3")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: could not convert string to float: '0.25.3'
```

:cry: 