### PR TITLE
bug: pandas to_html() overriding border=0

### DIFF
--- a/q2templates/util.py
+++ b/q2templates/util.py
@@ -12,8 +12,9 @@ import shutil
 import pandas as pd
 
 
-def df_to_html(df, border=0, classes=('table', 'table-striped', 'table-hover'),
-               **kwargs):
+def df_to_html(df, border="0", classes=('table', 'table-striped',
+                                        'table-hover'), **kwargs):
+
     """Convert a dataframe to HTML without truncating contents.
 
     pandas will truncate cell contents that exceed 50 characters by default.


### PR DESCRIPTION
`pandas to_html()` method wasn't retaining the border default in our `df_to_html()` method (i.e. `0`) - seems like this was due to their updated handling of None/NaN/etc. Once `0` was wrapped as a `str`, this retained our border default.