### PR TITLE
MAINT: update to use None instead of -1 to bypass dataframe display truncation

### DIFF
--- a/q2templates/util.py
+++ b/q2templates/util.py
@@ -43,7 +43,7 @@ def df_to_html(df, border="0", classes=('table', 'table-striped',
     .. [2] https://github.com/pandas-dev/pandas/issues/1852
 
     """
-    with pd.option_context('display.max_colwidth', -1):
+    with pd.option_context('display.max_colwidth', None):
         return df.to_html(border=border, classes=classes, **kwargs)
 
 


### PR DESCRIPTION
this is now how pandas formally supports this.
see https://github.com/pandas-dev/pandas/pull/31569

https://github.com/qiime2/distributions/pull/229
