### PR TITLE
MAINT: more compatible importlib asset handling

### DIFF
--- a/q2templates/reports/__init__.py
+++ b/q2templates/reports/__init__.py
@@ -11,16 +11,22 @@ import shutil
 from pathlib import Path
 
 
+def _copy_traversable(src, dst):
+    if src.is_dir():
+        dst.mkdir(parents=True, exist_ok=True)
+        for item in src.iterdir():
+            _copy_traversable(item, dst / item.name)
+    else:
+        with src.open('rb') as src_fh, dst.open('wb') as dst_fh:
+            shutil.copyfileobj(src_fh, dst_fh)
+
+
 def _copy_assets_dir(name, output_dir):
     output_dir = Path(output_dir)
     package = '.'.join(['q2templates', 'reports', 'built_assets', name])
-    with importlib.resources.path(package, '') as resource_path:
-        for item in resource_path.iterdir():
-            destination = output_dir / item.name
-            if item.is_dir():
-                shutil.copytree(item, destination, dirs_exist_ok=True)
-            else:
-                shutil.copy2(item, destination)
+    resource_path = importlib.resources.files(package)
+    for item in resource_path.iterdir():
+        _copy_traversable(item, output_dir / item.name)
 
 
 def matryoshka_template(output_dir, index):


### PR DESCRIPTION
Python 3.12 has an improved API for traversable directories, but chokes on namespace packages. Python 3.10 is fine with namespace packages, but has no API for traversable directories.

This change ignores both problems by just recursively constructing directories from whatever importlib does hand us.

This is arguably a better implementation than the previous shutil branch and should be compatible with pretty much anything importlib may eventually choose to create or resolve.